### PR TITLE
Use proper string notation in batch script restrictions

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS="-Xms256m -Xmx1024m"
+set DEFAULT_JVM_OPTS=-Xms256m -Xmx1024m
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome


### PR DESCRIPTION
Currently when use in \gradle-aem-multi

`gradlew fork`

there is an error:

> Invalid initial heap size: -Xms256m -Xmx1024m
> Error: Could not create the Java Virtual Machine.
> Error: A fatal exception has occurred. Program will exit.

Pull request use proper notation in gradlew.bat
